### PR TITLE
Docs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -48,7 +48,7 @@ mypy deepdrivewe/               # type check
 
 ### Docs
 ```bash
-mkdocs build --strict
+properdocs build --strict
 ```
 
 ## Architecture

--- a/.claude/skills/deepdrivewe-example/SKILL.md
+++ b/.claude/skills/deepdrivewe-example/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: deepdrivewe-example
+description: Use this skill when building a new example or custom workflow with DeepDriveWE (weighted ensemble MD on the Academy multi-agent framework). Covers project layout, agent subclassing, Pydantic config models, binner/recycler/resampler selection, Parsl compute configs, and verification steps.
+---
+
+# Building a New DeepDriveWE Example
+
+This skill guides Claude through creating a new example under `examples/`
+that runs a weighted ensemble workflow with DeepDriveWE. Use it when
+the user asks for a new example, a new protein system, a new MD engine
+wrapper, or any custom DDW workflow.
+
+## Before You Start
+
+Gather these requirements from the user:
+
+1. **System / use case** -- folding protein? Ligand binding? Conformational
+   sampling? Custom synthetic system?
+2. **MD engine** -- OpenMM, AMBER, or a custom/synthetic engine?
+3. **Progress coordinate** -- RMSD to reference? Distance? Latent-space
+   embedding? Multi-dimensional?
+4. **Target direction** -- low pcoord is the target (`LowRecycler`,
+   typical for folding) or high pcoord is the target (`HighRecycler`,
+   typical for unbinding)?
+5. **Compute** -- local laptop, multi-GPU workstation, or HPC (Slurm/PBS)?
+6. **Starting from** -- a fresh example or extending an existing one
+   (`examples/openmm_ntl9_hk/`, `examples/minimal_westpa/`)?
+
+If the user is vague on any of the above, ask before generating code.
+
+## Project Layout
+
+Every DeepDriveWE example follows this structure:
+
+```
+examples/<name>/
+├── main.py              # Entry point: parse args, build ensemble, launch workflow
+├── workflow.py          # Agent subclasses + Pydantic config models
+├── config.yaml          # All experiment parameters (edit per-run)
+├── common_files/        # Shared reference files (reference.pdb, topology, etc.)
+└── inputs/
+    └── bstates/         # Basis state structures in per-walker subdirectories
+        ├── 00/
+        ├── 01/
+        └── ...
+```
+
+### Critical rule: serializable classes live in `workflow.py`
+
+Parsl workers use `dill` to deserialize agent classes. `dill` can only
+resolve classes from importable modules -- not from `__main__`. So:
+
+- Agent subclasses (`MySimAgent`, `MyWestpaAgent`) -> **`workflow.py`**
+- Pydantic config models (`SimulationConfig`, `InferenceConfig`,
+  `ExperimentSettings`) -> **`workflow.py`**
+- `argparse`, `Manager` setup, `ParslPoolExecutor`, signal handling ->
+  **`main.py`**
+
+The reference example `examples/openmm_ntl9_hk/` demonstrates this
+split. Follow it.
+
+## Step-by-Step
+
+### Step 1: Define config models in `workflow.py`
+
+Subclass `deepdrivewe.api.BaseModel` (which adds YAML load/dump) for
+anything loaded from `config.yaml`:
+
+```python
+from deepdrivewe.api import BaseModel, BasisStates, TargetState
+from deepdrivewe.parsl import ComputeConfigTypes
+from pydantic import Field
+
+
+class SimulationConfig(BaseModel):
+    # Fields specific to your MD engine / reporter
+    ...
+
+
+class InferenceConfig(BaseModel):
+    sims_per_bin: int = Field(default=4)
+    # + any other resampler knobs
+
+
+class ExperimentSettings(BaseModel):
+    output_dir: Path
+    num_iterations: int = Field(ge=1)
+    basis_states: BasisStates
+    target_states: list[TargetState]
+    simulation_config: SimulationConfig
+    inference_config: InferenceConfig
+    compute_config: ComputeConfigTypes
+    # + basis_state_initializer (callable that returns initial pcoord)
+```
+
+Use `pydantic.field_validator` to resolve file paths and create output
+dirs at config-load time -- fail fast on bad input.
+
+### Step 2: Subclass `SimulationAgent`
+
+```python
+from deepdrivewe.workflows.westpa import SimulationAgent
+
+class MySimAgent(SimulationAgent):
+    def __init__(self, westpa_handle, sim_config, output_dir, logfile=None):
+        super().__init__(westpa_handle, logfile=logfile)
+        self.sim_config = sim_config
+        self.output_dir = output_dir
+
+    def run_simulation(self, metadata: SimMetadata) -> SimResult:
+        metadata.mark_simulation_start()
+        # 1. Run MD starting from metadata.parent_restart_file
+        # 2. Compute pcoord (RMSD / distance / latent embedding / whatever)
+        # 3. Set metadata.restart_file, metadata.pcoord
+        metadata.mark_simulation_end()
+        return SimResult(data={'pcoord': pcoord_array}, metadata=metadata)
+```
+
+`run_simulation` is blocking; the base class offloads it to a thread
+pool via `agent_run_sync`, so don't make it `async`. Heavy per-agent
+state (ML models, loaded topologies) should be initialized in
+`agent_on_startup` (async) or `__init__`.
+
+### Step 3: Subclass `WestpaAgent`
+
+```python
+from deepdrivewe.workflows.westpa import WestpaAgent
+from deepdrivewe.binners import RectilinearBinner
+from deepdrivewe.recyclers import LowRecycler
+from deepdrivewe.resamplers import HuberKimResampler
+
+class MyWestpaAgent(WestpaAgent):
+    def __init__(self, simulation_handles, max_iterations, ensemble,
+                 checkpointer=None, inference_config=None, logfile=None):
+        super().__init__(simulation_handles, max_iterations, ensemble,
+                         checkpointer=checkpointer, logfile=logfile)
+        self.inference_config = inference_config or InferenceConfig()
+
+    def run_inference(self, sim_results):
+        cur_sims = [r.metadata for r in sim_results]
+        cfg = self.inference_config
+
+        binner = RectilinearBinner(
+            bins=[...],                              # design per use case
+            bin_target_counts=cfg.sims_per_bin,
+            target_state_inds=0,
+        )
+        recycler = LowRecycler(                      # or HighRecycler
+            basis_states=self.basis_states,
+            target_threshold=self.target_states[0].pcoord[0],
+        )
+        resampler = HuberKimResampler(
+            sims_per_bin=cfg.sims_per_bin,
+        )
+        return resampler.run(cur_sims, binner, recycler)
+```
+
+### Step 4: Write `main.py`
+
+The `main.py` pattern from `examples/openmm_ntl9_hk/main.py` is the
+canonical template. Key structure:
+
+1. `_export_pythonpath()` -- add the example dir to `PYTHONPATH` so
+   Parsl workers can import `workflow`.
+2. Parse args (`-c config.yaml`, `--exchange local|globus`).
+3. Load `ExperimentSettings.from_yaml(args.config)`.
+4. Dump the resolved config back to `output_dir/params.yaml` (audit).
+5. Build `ParslPoolExecutor` from `cfg.compute_config.get_parsl_config(...)`.
+6. Initialize or resume the `WeightedEnsemble` via `EnsembleCheckpointer`.
+7. Install a SIGTERM handler that calls `gpu_executor.shutdown()` and
+   `os._exit(0)` (Parsl workers survive the main process; normal
+   shutdown hangs).
+8. Run `run_westpa_workflow(...)` inside `async with Manager(...)`.
+
+### Step 5: Write `config.yaml`
+
+Mirror the field structure of `ExperimentSettings`. Keep it heavily
+commented -- users will edit this per-run. Use the `openmm_ntl9_hk`
+config as a template.
+
+### Step 6: Verify
+
+First run with `num_iterations: 2` and a tiny `simulation_length_ns`:
+
+```bash
+cd examples/<name>
+python main.py -c config.yaml
+```
+
+Check:
+
+- `results/runtime.log` shows the iteration loop firing.
+- `results/checkpoints/checkpoint-000002.json` exists.
+- `results/west.h5` is written.
+- `results/simulation/000001/*/` contains per-walker output.
+
+Only scale up iterations / simulation length after the small run
+passes.
+
+## Component Selection Guide
+
+### Binners (`deepdrivewe.binners`)
+
+| Binner | When to Use |
+|---|---|
+| `RectilinearBinner` | 1D progress coordinate with fixed boundaries. The default. |
+| `MultiRectilinearBinner` | N-D progress coordinate (e.g., RMSD + radius of gyration). |
+
+Bin design tip: put finer bins near the target to increase resolution
+where it matters. The NTL9 example uses 0.1 A bins from 1.0-4.6 A,
+0.2 A from 4.6-6.6 A, 0.6 A beyond.
+
+### Recyclers (`deepdrivewe.recyclers`)
+
+| Recycler | When to Use |
+|---|---|
+| `LowRecycler` | Target is at low pcoord (folded protein, bound ligand). |
+| `HighRecycler` | Target is at high pcoord (unfolded, unbound, dissociated). |
+
+### Resamplers (`deepdrivewe.resamplers`)
+
+| Resampler | When to Use |
+|---|---|
+| `HuberKimResampler` | Standard Huber-Kim split/merge. Start here. |
+| `SplitLowResampler` / `SplitHighResampler` | Split-only variants (no merging) near target. |
+| `LOFLowResampler` | ML-enhanced resampling using local outlier factor in a latent space -- requires `deepdrivewe.ai` models. |
+
+### Compute configs (`deepdrivewe.parsl`)
+
+| Config | When to Use |
+|---|---|
+| `LocalConfig` | Single machine, CPU-only (testing / tiny systems). |
+| `WorkstationConfig` | Multi-GPU workstation (`available_accelerators=["0","1",...]`). |
+| `VistaConfig` | TACC Vista cluster. |
+| Slurm / PBS variants | Other HPC schedulers -- see `ComputeConfigTypes`. |
+
+## Common Extension Points
+
+- **Custom progress coordinate** -- override `run_simulation`, compute
+  whatever scalar/vector you want, assign to `metadata.pcoord` as
+  `list[list[float]]` (shape: `(n_frames, pcoord_dim)`).
+- **Custom reporter / data products** -- add keys to
+  `SimResult.data` (`np.ndarray` values). These are passed to
+  `run_inference` unchanged and can feed an ML-based resampler.
+- **Custom resampler** -- subclass `deepdrivewe.resamplers.Resampler`
+  and override `.run(cur_sims, binner, recycler)`.
+- **ML-driven resampling** -- load a trained model in
+  `agent_on_startup`, use it in `run_inference` to compute
+  latent-space coordinates, and use `LOFLowResampler` or a custom
+  resampler.
+
+## Gotchas
+
+- **`from __future__ import annotations`** is required in every file
+  (project ruff rule).
+- **Line length 79** chars. Single quotes. Numpy docstrings.
+- Don't put agent classes or config models in `main.py` -- Parsl
+  workers can't deserialize them from `__main__`.
+- The first `SimMetadata` batch comes from
+  `ensemble.next_sims` (populated by
+  `ensemble.initialize_basis_states(...)`). Don't build it manually
+  unless you're mocking.
+- `EnsembleCheckpointer` resumes automatically if `output_dir`
+  contains a checkpoint -- always construct it before the
+  `WeightedEnsemble` so resumes are transparent.
+
+## References
+
+- Canonical production example: `examples/openmm_ntl9_hk/`
+- Minimal stateless example: `examples/minimal_westpa/`
+- Full DeepDriveWE (sim + train + inference): `examples/minimal_pattern/`
+- API docs: see `deepdrivewe.api`, `deepdrivewe.workflows.westpa`,
+  `deepdrivewe.binners`, `deepdrivewe.recyclers`,
+  `deepdrivewe.resamplers`, `deepdrivewe.parsl`.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# MkDocs build output
+site/
+
 # Created by https://www.toptal.com/developers/gitignore/api/sublimetext,pycharm,visualstudiocode,macos,python,jupyternotebooks
 # Edit at https://www.toptal.com/developers/gitignore?templates=sublimetext,pycharm,visualstudiocode,macos,python,jupyternotebooks
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
       - id: check-docstring-first
       - id: check-json
       - id: check-yaml
+        exclude: ^properdocs\.yml$
       - id: check-merge-conflict
       - id: name-tests-test
   - repo: 'https://github.com/codespell-project/codespell'

--- a/README.md
+++ b/README.md
@@ -45,3 +45,42 @@ To test the code, run the following command:
 pre-commit run --all-files
 tox -e py310
 ```
+
+### Building the Documentation
+
+Documentation is built with [ProperDocs](https://properdocs.org/) (a
+continuation of MkDocs 1.x).
+```bash
+pip install -e '.[dev,docs]'
+properdocs serve
+```
+Then open http://localhost:8000 in your browser. For a production build:
+```bash
+properdocs build --strict
+```
+
+## Citation
+
+If you use DeepDriveWE in your research, please cite:
+
+> Leung, J. M. G.; Frazee, N. C.; Brace, A.; Bogetti, A. T.;
+> Ramanathan, A.; Chong, L. T. "Unsupervised Learning of Progress
+> Coordinates during Weighted Ensemble Simulations: Application to NTL9
+> Protein Folding." *Journal of Chemical Theory and Computation* **2025**,
+> *21* (7), 3691--3699.
+> [DOI: 10.1021/acs.jctc.4c01136](https://pubs.acs.org/doi/full/10.1021/acs.jctc.4c01136)
+
+BibTeX:
+
+```bibtex
+@article{leung2025unsupervised,
+  title={Unsupervised Learning of Progress Coordinates during Weighted Ensemble Simulations: Application to NTL9 Protein Folding},
+  author={Leung, Jeremy MG and Frazee, Nicolas C and Brace, Alexander and Bogetti, Anthony T and Ramanathan, Arvind and Chong, Lillian T},
+  journal={Journal of chemical theory and computation},
+  volume={21},
+  number={7},
+  pages={3691--3699},
+  year={2025},
+  publisher={ACS Publications}
+}
+```

--- a/deepdrivewe/ai/utils.py
+++ b/deepdrivewe/ai/utils.py
@@ -31,9 +31,9 @@ class LatentSpaceHistory:
 
         Parameters
         ----------
-        z: array-like
+        z : array-like
             The latent space coordinates (n_frames, d)
-        pcords: array-like
+        pcoords : array-like
             The progress coordinates (n_frames, 1)
         """
         self.z = z
@@ -50,18 +50,15 @@ class LatentSpaceHistory:
 
         Parameters
         ----------
-        x: array-like
-            X data for the scatter plot
-        y: array-like
-            Y data for the scatter plot
-        color: array-like
-            Data used for coloring the points
-        xlabel: str
-            Label for the X-axis
-        ylabel: str
-            Label for the Y-axis
-        title: str
-            Title of the plot
+        output_path : Path
+            Path to save the plot image.
+        color : array-like, optional
+            Data used for coloring the points. Defaults to
+            progress coordinates.
+        cblabel : str
+            Label for the colorbar.
+        title : str
+            Title of the plot.
         """
         import matplotlib.pyplot as plt
 

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -1,0 +1,114 @@
+# Architecture
+
+DeepDriveWE-Academy is built on the
+[Academy](https://docs.academy-agents.org/stable/) multi-agent framework.
+Simulations and resampling logic run as independent agents that
+communicate asynchronously through typed messages.
+
+## Agent Model
+
+Every workflow has two agent types:
+
+```mermaid
+graph LR
+    M["main()"] -->|launch| SA["SimulationAgent(s)"]
+    M -->|launch| WA["WestpaAgent"]
+
+    SA -->|"SimResult"| WA
+    WA -->|"SimMetadata"| SA
+```
+
+**SimulationAgent**
+:   Runs a single MD simulation per invocation. Receives `SimMetadata`
+    (walker weight, restart file, parent pcoord), runs the simulation in
+    a thread pool via `agent_run_sync`, and sends the `SimResult` back
+    to the WestpaAgent.
+
+**WestpaAgent**
+:   Orchestrates the iteration cycle. Buffers incoming `SimResult`
+    objects until the full batch is collected, then runs
+    user-defined inference (binning, recycling, resampling) and
+    dispatches the next iteration of simulations round-robin.
+
+## Communication Flow
+
+1. `run_westpa_workflow` registers and launches all agents.
+2. The initial batch of `SimMetadata` (from `ensemble.next_sims`) is
+   dispatched round-robin to `SimulationAgent` instances.
+3. Each `SimulationAgent` calls its `run_simulation` method, then
+   sends the result to `WestpaAgent.receive_simulation_data`.
+4. Once all results arrive, `WestpaAgent.run_westpa` fires:
+    - Calls `run_inference` (user-defined resampling).
+    - Advances ensemble state via `ensemble.advance_iteration`.
+    - Checkpoints the ensemble.
+    - Dispatches the next round of simulations.
+5. Steps 3--4 repeat until `max_iterations` is reached.
+
+## Academy Primitives
+
+See the [Academy documentation](https://docs.academy-agents.org/stable/)
+for more information.
+
+| Primitive | Purpose |
+|-----------|---------|
+| [`Agent`](https://docs.academy-agents.org/stable/api/agent/#academy.agent.Agent) | Base class for all agents. Subclass to add state and methods. |
+| [`@action`](https://docs.academy-agents.org/stable/api/agent/#academy.agent.action) | Marks an async method as remotely callable by other agents. |
+| [`@loop`](https://docs.academy-agents.org/stable/api/agent/#academy.agent.loop) | Marks an async method as a background control loop. |
+| [`Handle[T]`](https://docs.academy-agents.org/stable/api/handle/) | Typed proxy for calling actions on a remote agent of type `T`. |
+| [`Manager`](https://docs.academy-agents.org/stable/api/manager/) | Orchestrates agent registration, launching, and shutdown. |
+| [`LocalExchangeFactory`](https://docs.academy-agents.org/stable/api/exchange/local/) | In-process message transport (single machine). |
+| [`HttpExchangeFactory`](https://docs.academy-agents.org/stable/api/exchange/cloud/) | Cloud message transport via the Academy Exchange (multi-node). |
+
+## Execution Model
+
+Simulations are CPU/GPU-bound and are offloaded to a
+[Parsl](https://parsl-project.org/) executor. The WestpaAgent
+runs on a CPU thread. The Academy `Manager` is initialized with named
+executors:
+
+```python
+async with await Manager.from_exchange_factory(
+    factory=LocalExchangeFactory(),
+    executors={
+        'gpu': ParslPoolExecutor(parsl_config),
+        'cpu': ThreadPoolExecutor(max_workers=1),
+    },
+    default_executor='gpu',
+) as manager:
+    ...
+```
+
+Agents are assigned to executors at launch time:
+
+```python
+await manager.launch(OpenMMSimAgent, ..., executor='gpu')
+await manager.launch(HuberKimWestpaAgent, ..., executor='cpu')
+```
+
+## Checkpointing
+
+`EnsembleCheckpointer` saves the full ensemble state after each
+iteration:
+
+- **JSON checkpoints** -- one file per iteration
+  (`checkpoint-000001.json`) containing the serialized
+  `WeightedEnsemble`.
+- **HDF5 log** -- a cumulative `west.h5` file in WESTPA-compatible
+  format for analysis with standard WE tools.
+
+Workflows automatically resume from the latest checkpoint when
+restarted.
+
+## Extending the Framework
+
+To build a custom workflow:
+
+1. **Subclass `SimulationAgent`** -- override `run_simulation` to run
+   your simulation engine and compute progress coordinates.
+2. **Subclass `WestpaAgent`** -- override `run_inference` to plug in
+   your binning, recycling, and resampling strategy.
+3. **Call `run_westpa_workflow`** -- pass your agent types, ensemble
+   configuration, and compute settings.
+
+See the [OpenMM NTL9 tutorial](../tutorials/openmm-ntl9-hk.md) for a
+complete example.

--- a/docs/concepts/weighted-ensemble.md
+++ b/docs/concepts/weighted-ensemble.md
@@ -1,0 +1,100 @@
+# Weighted Ensemble
+
+Weighted ensemble (WE) is an enhanced sampling method for molecular
+dynamics that accelerates the observation of rare events -- such as
+protein folding or ligand binding -- without biasing the dynamics.
+
+## How It Works
+
+Instead of running a single long trajectory, WE maintains an **ensemble
+of short simulations** (called *walkers*) that are periodically pruned
+and replicated based on their progress toward a target state.
+
+Each iteration of the WE algorithm proceeds in three stages:
+
+```mermaid
+graph LR
+    S["Simulate"] --> B["Bin & Recycle"] --> R["Resample"]
+    R -->|next iteration| S
+```
+
+### 1. Simulate
+
+Each walker runs a short MD segment (e.g., 10 ps) starting from its
+current restart file. At the end of the segment, a **progress
+coordinate** (pcoord) is computed -- typically RMSD to a reference
+structure -- that measures how close the walker is to the target state.
+
+### 2. Bin and Recycle
+
+Walkers are sorted into **bins** along the progress coordinate.
+Walkers that reach the target state (e.g., RMSD < 1.0 A) are
+**recycled**: their statistical weight is recorded and they are reset to
+a basis (starting) state. This allows the ensemble to continuously
+generate new transition events.
+
+### 3. Resample
+
+Within each bin, walkers are **split** (replicated) or **merged**
+(combined) to maintain a target number of walkers per bin. Splitting
+focuses computational effort on under-sampled regions of progress
+coordinate space, while merging avoids wasting resources on
+over-represented regions.
+
+!!! important
+    Resampling preserves the statistical weights of walkers so that
+    ensemble averages remain unbiased. This is a key advantage of WE
+    over other enhanced sampling methods.
+
+## Key Concepts
+
+**Walker**
+:   A single simulation trajectory, characterized by its statistical
+    weight, progress coordinate, and restart file.
+
+**Progress Coordinate (pcoord)**
+:   A low-dimensional measure of progress toward the target state.
+    Common choices include RMSD, fraction of native contacts, or
+    distance to a binding site.
+
+**Bin**
+:   A partition of progress coordinate space. Walkers within the same
+    bin compete for computational resources during resampling.
+
+**Basis State**
+:   An initial (typically unfolded or unbound) configuration from which
+    walkers start or are recycled to.
+
+**Target State**
+:   The desired end state (e.g., folded protein). Walkers that reach the
+    target state are recycled.
+
+## Algorithms in DeepDriveWE
+
+DeepDriveWE provides several pluggable components:
+
+| Component | Options |
+|-----------|---------|
+| **Binners** | [`RectilinearBinner`][deepdrivewe.binners.rectilinear.RectilinearBinner], [`MultiRectilinearBinner`][deepdrivewe.binners.multirectilinear.MultiRectilinearBinner] |
+| **Recyclers** | [`LowRecycler`][deepdrivewe.recyclers.low.LowRecycler], [`HighRecycler`][deepdrivewe.recyclers.high.HighRecycler] |
+| **Resamplers** | [`HuberKimResampler`][deepdrivewe.resamplers.huber_kim.HuberKimResampler], [`SplitLowResampler`][deepdrivewe.resamplers.low.SplitLowResampler], [`SplitHighResampler`][deepdrivewe.resamplers.high.SplitHighResampler], [`LOFLowResampler`][deepdrivewe.resamplers.lof.LOFLowResampler] |
+
+The **Huber-Kim** resampler is the default and implements the algorithm
+described in
+[Huber & Kim (1996)](https://doi.org/10.1016/S0006-3495(96)79552-8),
+which maintains a fixed number of walkers per bin by balancing split and
+merge operations.
+
+## Further Reading
+
+- Zwier, M. C. *et al.* "WESTPA: An Interoperable, Highly Scalable
+  Software Package for Weighted Ensemble Simulation and Analysis."
+  [*J. Chem. Theory Comput.* **2015**, *11* (2),
+  800--809](https://pubs.acs.org/doi/10.1021/ct5010615).
+- Zuckerman, D. M. & Chong, L. T. "Weighted Ensemble Simulation:
+  Review of Methodology, Applications, and Software."
+  [*Annu. Rev. Biophys.* (2017)](https://www.annualreviews.org/content/journals/10.1146/annurev-biophys-070816-033834).
+- Leung, J. M. G. *et al.* "Unsupervised Learning of Progress
+  Coordinates during Weighted Ensemble Simulations: Application to
+  NTL9 Protein Folding." [*J. Chem. Theory Comput.* **2025**, *21* (7),
+  3691--3699](https://pubs.acs.org/doi/full/10.1021/acs.jctc.4c01136).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,86 @@
+# Contributing
+
+Contributions are welcome! This guide covers how to set up a development
+environment, run the test suite, and build the documentation locally.
+
+## Development Setup
+
+Create a virtual environment and install all development and
+documentation dependencies:
+
+```bash
+git clone git@github.com:braceal/deepdrivewe-academy.git
+cd deepdrivewe-academy
+python -m venv venv
+source venv/bin/activate
+pip install -U pip setuptools wheel
+pip install -e '.[dev,docs]'
+pre-commit install
+```
+
+## Running Tests
+
+```bash
+# Run the full test suite with coverage
+pytest
+
+# Run a single test
+pytest tests/path_to_test.py::test_name
+
+# Run via tox (isolated environment)
+tox -e py310
+```
+
+## Linting and Type Checking
+
+Pre-commit hooks run ruff and mypy automatically on each commit. You can
+also run them manually:
+
+```bash
+# Run all pre-commit hooks
+pre-commit run --all-files
+
+# Individual tools
+ruff check .         # lint
+ruff format .        # format
+mypy deepdrivewe/    # type check
+```
+
+## Building the Documentation
+
+The documentation is built with
+[ProperDocs](https://properdocs.org/) (a continuation of MkDocs 1.x)
+and the Material theme. API reference pages are auto-generated from
+docstrings.
+
+```bash
+# Install docs dependencies (included in dev setup above)
+pip install -e '.[dev,docs]'
+
+# Live preview with hot reload
+properdocs serve
+
+# Production build (strict mode)
+properdocs build --strict
+```
+
+Then open <http://localhost:8000> in your browser to preview.
+
+## Code Style
+
+- **Line length**: 79 characters
+- **Quotes**: single quotes (enforced by ruff)
+- **Imports**: `from __future__ import annotations` required in every
+  file; force single-line imports
+- **Docstrings**: numpy convention
+- **Type annotations**: required on all function signatures
+- **Immutability**: prefer `@dataclass(frozen=True)` and `NamedTuple`
+
+## Pull Requests
+
+1. Create a branch from `develop` (not `main`).
+2. Name the branch `feature/<issue>-<slug>`, `bugfix/<issue>-<slug>`,
+   or `chore/<issue>-<slug>`.
+3. Write tests for new functionality.
+4. Make sure `pre-commit run --all-files` and `pytest` pass.
+5. Open a PR targeting `develop`.

--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -1,0 +1,37 @@
+"""Generate the code reference pages and navigation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import mkdocs_gen_files
+
+nav = mkdocs_gen_files.Nav()
+
+root = Path(__file__).parent.parent
+src = root / 'deepdrivewe'
+
+for path in sorted(src.rglob('*.py')):
+    module_path = path.relative_to(root)
+    doc_path = path.relative_to(root).with_suffix('.md')
+    full_doc_path = Path('reference', doc_path)
+
+    parts = tuple(module_path.with_suffix('').parts)
+
+    if parts[-1] == '__init__':
+        parts = parts[:-1]
+        doc_path = doc_path.with_name('index.md')
+        full_doc_path = full_doc_path.with_name('index.md')
+    elif parts[-1] == '__main__':
+        continue
+
+    nav[parts] = doc_path.as_posix()
+
+    with mkdocs_gen_files.open(full_doc_path, 'w') as fd:
+        ident = '.'.join(parts)
+        fd.write(f'::: {ident}\n')
+
+    mkdocs_gen_files.set_edit_path(full_doc_path, path.relative_to(root))
+
+with mkdocs_gen_files.open('reference/SUMMARY.md', 'w') as nav_file:
+    nav_file.writelines(nav.build_literate_nav())

--- a/docs/getting-started/claude-skill.md
+++ b/docs/getting-started/claude-skill.md
@@ -1,0 +1,117 @@
+# Claude Skill: Build a DeepDriveWE Example
+
+This project ships a [Claude Code](https://claude.com/claude-code)
+skill that walks Claude through creating a new DeepDriveWE example
+end-to-end. Install it once, then ask Claude something like
+*"build a new DeepDriveWE example for ligand binding with AMBER"* --
+Claude automatically loads the skill and follows the project's
+conventions (directory layout, agent subclassing, binner/resampler
+choices, Parsl compute configs, verification steps).
+
+## What the Skill Covers
+
+- Required project layout (`main.py`, `workflow.py`, `config.yaml`,
+  `common_files/`, `inputs/bstates/`).
+- Why Parsl-serializable classes must live in `workflow.py`, not
+  `main.py`.
+- How to subclass
+  [`SimulationAgent`][deepdrivewe.workflows.westpa.SimulationAgent]
+  and [`WestpaAgent`][deepdrivewe.workflows.westpa.WestpaAgent].
+- Selection guide for binners, recyclers, resamplers, and compute
+  configs.
+- Checkpoint/resume pattern and SIGTERM handling.
+- Verification steps before scaling up.
+
+## Where to Install It
+
+Claude Code loads skills from two locations:
+
+=== "User-level (recommended)"
+
+    ```
+    ~/.claude/skills/deepdrivewe-example/SKILL.md
+    ```
+
+    Available in every project you work on. Install this way if you
+    plan to build DeepDriveWE examples across multiple checkouts or
+    downstream projects.
+
+=== "Project-level"
+
+    ```
+    .claude/skills/deepdrivewe-example/SKILL.md
+    ```
+
+    Committed to this repo and automatically available whenever you
+    open it in Claude Code. No install step needed -- it's already
+    here.
+
+## Install (User-Level)
+
+=== "curl"
+
+    ```bash
+    mkdir -p ~/.claude/skills/deepdrivewe-example
+    curl -fsSL \
+      https://raw.githubusercontent.com/braceal/deepdrivewe-academy/main/.claude/skills/deepdrivewe-example/SKILL.md \
+      -o ~/.claude/skills/deepdrivewe-example/SKILL.md
+    ```
+
+=== "From a local checkout"
+
+    ```bash
+    mkdir -p ~/.claude/skills/deepdrivewe-example
+    cp .claude/skills/deepdrivewe-example/SKILL.md \
+       ~/.claude/skills/deepdrivewe-example/SKILL.md
+    ```
+
+=== "wget"
+
+    ```bash
+    mkdir -p ~/.claude/skills/deepdrivewe-example
+    wget -O ~/.claude/skills/deepdrivewe-example/SKILL.md \
+      https://raw.githubusercontent.com/braceal/deepdrivewe-academy/main/.claude/skills/deepdrivewe-example/SKILL.md
+    ```
+
+Once installed, Claude Code will see `deepdrivewe-example` in its
+skill list on the next session start.
+
+## How to Trigger It
+
+Just ask in natural language. Claude matches the user request against
+the skill's description and loads the skill automatically.
+
+Example prompts:
+
+> "Create a new DeepDriveWE example for NTL9 folding using AMBER
+> instead of OpenMM."
+
+> "Build a new weighted ensemble workflow to study ligand unbinding
+> from a kinase. Use a distance-based progress coordinate."
+
+> "Set up a minimal DDWE example that runs on a single laptop CPU
+> with a synthetic simulation."
+
+## Contents Preview
+
+The skill is ~200 lines of structured guidance. A condensed outline:
+
+1. **Before You Start** -- requirements gathering (system, MD engine,
+   progress coordinate, target direction, compute, starting point).
+2. **Project Layout** -- required files and the critical rule about
+   where serializable classes must live.
+3. **Step-by-Step** (6 steps) -- config models, agent subclassing,
+   `main.py` pattern, `config.yaml` pattern, verification.
+4. **Component Selection Guide** -- tables for picking the right
+   binner, recycler, resampler, and compute config.
+5. **Common Extension Points** -- custom pcoords, data products,
+   resamplers, ML-driven workflows.
+6. **Gotchas** -- project conventions and easy-to-miss pitfalls.
+
+View the full source at
+[.claude/skills/deepdrivewe-example/SKILL.md](https://github.com/braceal/deepdrivewe-academy/blob/main/.claude/skills/deepdrivewe-example/SKILL.md).
+
+## Updating the Skill
+
+If you improve the skill locally, please open a PR against `develop`
+so everyone benefits. See the [Contributing](../contributing.md) guide.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,82 @@
+# Installation
+
+## Basic Install
+
+Clone the repository and install in editable mode:
+
+```bash
+git clone git@github.com:braceal/deepdrivewe-academy.git
+cd deepdrivewe-academy
+pip install -e .
+```
+
+## Full Install with MD Dependencies
+
+For running molecular dynamics simulations with OpenMM and AmberTools,
+use conda to install the simulation backends first:
+
+```bash
+git clone git@github.com:braceal/deepdrivewe-academy.git
+cd deepdrivewe-academy
+
+conda create -n deepdrivewe python=3.11 -y
+conda activate deepdrivewe
+conda install -c conda-forge openmm=8.1
+conda install omnia::ambertools -y
+pip install -e .
+```
+
+## Deep Learning Models
+
+To use the built-in AI models (convolutional VAE, adversarial
+autoencoder), install the correct version of
+[PyTorch](https://pytorch.org/get-started/locally/) for your system and
+GPU drivers:
+
+```bash
+pip install torch
+```
+
+!!! note
+    The `mdlearn` dependency may require an earlier version of PyTorch.
+    If you encounter compatibility issues, try:
+    ```bash
+    pip install torch==1.12
+    ```
+
+## Development Setup
+
+For contributing or running the test suite:
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -U pip setuptools wheel
+pip install -e '.[dev,docs]'
+pre-commit install
+```
+
+Verify the setup:
+
+```bash
+pre-commit run --all-files
+pytest
+```
+
+## Documentation Build
+
+To build the documentation locally:
+
+```bash
+pip install -e '.[dev,docs]'
+properdocs serve
+```
+
+Then open <http://localhost:8000> in your browser. For a production
+build with strict checking:
+
+```bash
+properdocs build --strict
+```
+
+See the [Contributing](../contributing.md) guide for more details.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,79 @@
+# Quickstart
+
+This guide walks through the minimal steps to run a weighted ensemble
+workflow with DeepDriveWE-Academy.
+
+## Concepts
+
+A DeepDriveWE workflow has two agent types:
+
+1. **SimulationAgent** -- runs one MD simulation per call and returns a
+   `SimResult`.
+2. **WestpaAgent** -- collects results from all walkers in an iteration,
+   applies binning/recycling/resampling, and dispatches the next round.
+
+You subclass each agent to inject your own simulation and inference
+logic, then hand them to `run_westpa_workflow` which handles
+registration, launching, and communication.
+
+## Minimal Pattern
+
+The simplest workflow defines `run_simulation` and `run_inference`:
+
+```python
+from deepdrivewe.api import SimMetadata, SimResult, IterationMetadata
+from deepdrivewe.workflows import SimulationAgent, WestpaAgent
+
+
+class MySimAgent(SimulationAgent):
+    def run_simulation(self, metadata: SimMetadata) -> SimResult:
+        # Your simulation logic here
+        ...
+        return SimResult(data={'pcoord': pcoord}, metadata=metadata)
+
+
+class MyWestpaAgent(WestpaAgent):
+    def run_inference(
+        self,
+        sim_results: list[SimResult],
+    ) -> tuple[list[SimMetadata], list[SimMetadata], IterationMetadata]:
+        # Your binning + resampling logic here
+        ...
+        return cur_sims, next_sims, metadata
+```
+
+## Running the Workflow
+
+Wire everything together with `run_westpa_workflow`:
+
+```python
+import asyncio
+from academy.exchange.local import LocalExchangeFactory
+from academy.manager import Manager
+from deepdrivewe.api import WeightedEnsemble
+from deepdrivewe.workflows import run_westpa_workflow
+
+
+async def main():
+    async with await Manager.from_exchange_factory(
+        factory=LocalExchangeFactory(),
+    ) as manager:
+        await run_westpa_workflow(
+            manager=manager,
+            sim_agent_type=MySimAgent,
+            westpa_agent_type=MyWestpaAgent,
+            max_iterations=10,
+            ensemble=ensemble,  # WeightedEnsemble with basis/target states
+        )
+
+asyncio.run(main())
+```
+
+## Next Steps
+
+- See the [OpenMM NTL9 tutorial](../tutorials/openmm-ntl9-hk.md) for a
+  complete protein-folding example with GPU-distributed MD.
+- Read the [Architecture](../concepts/architecture.md) page to
+  understand the agent communication model.
+- Browse the [API Reference](../reference/) for full class
+  documentation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,84 @@
+# DeepDriveWE-Academy
+
+**Weighted ensemble molecular dynamics using the Academy multi-agent framework.**
+
+DeepDriveWE-Academy is a Python implementation of
+[DeepDriveWE](https://pubs.acs.org/doi/full/10.1021/acs.jctc.4c01136)
+built on the [Academy](https://docs.academy-agents.org/stable/) multi-agent
+framework. It enables scalable weighted ensemble (WE) simulations where
+molecular dynamics walkers and resampling logic run as independent,
+communicating agents distributed across CPUs and GPUs.
+
+## Key Features
+
+- **Agent-based architecture** -- Simulation walkers and the WE
+  orchestrator are Academy agents that communicate asynchronously via
+  typed messages (`SimResult`, `SimMetadata`).
+- **Pluggable components** -- Swap binners, recyclers, resamplers, and
+  simulation engines independently.
+- **GPU-distributed MD** -- Simulations are offloaded to GPU workers
+  through [Parsl](https://parsl-project.org/), with built-in support for
+  workstations, Slurm, and PBS clusters.
+- **Checkpointing and resume** -- Ensemble state is saved after every
+  iteration in both JSON and WESTPA-compatible HDF5 format.
+- **AI-enhanced resampling** -- Optional deep learning models
+  (convolutional VAE, adversarial autoencoders) for latent-space--guided
+  resampling.
+
+## Quick Example
+
+```python
+from deepdrivewe.workflows import run_westpa_workflow
+
+await run_westpa_workflow(
+    manager=manager,
+    sim_agent_type=MySimAgent,
+    westpa_agent_type=MyWestpaAgent,
+    max_iterations=100,
+    ensemble=ensemble,
+)
+```
+
+See the [Quickstart](getting-started/quickstart.md) guide to get running
+in minutes, or follow the full
+[OpenMM NTL9 tutorial](tutorials/openmm-ntl9-hk.md) for a production
+protein-folding workflow.
+
+!!! tip "Build with Claude Code"
+    This project ships a [Claude Code](https://claude.com/claude-code)
+    skill that walks Claude through creating a new DeepDriveWE example
+    end-to-end. See the
+    [Claude Skill](getting-started/claude-skill.md) page to install
+    it, then ask Claude things like *"build a new DeepDriveWE example
+    for ligand unbinding with AMBER"*.
+
+## Citation
+
+If you use DeepDriveWE in your research, please cite:
+
+> Leung, J. M. G.; Frazee, N. C.; Brace, A.; Bogetti, A. T.;
+> Ramanathan, A.; Chong, L. T. "Unsupervised Learning of Progress
+> Coordinates during Weighted Ensemble Simulations: Application to NTL9
+> Protein Folding." *Journal of Chemical Theory and Computation* **2025**,
+> *21* (7), 3691--3699.
+> [DOI: 10.1021/acs.jctc.4c01136](https://pubs.acs.org/doi/full/10.1021/acs.jctc.4c01136)
+
+BibTeX:
+
+```bibtex
+@article{leung2025unsupervised,
+  title={Unsupervised Learning of Progress Coordinates during Weighted Ensemble Simulations: Application to NTL9 Protein Folding},
+  author={Leung, Jeremy MG and Frazee, Nicolas C and Brace, Alexander and Bogetti, Anthony T and Ramanathan, Arvind and Chong, Lillian T},
+  journal={Journal of chemical theory and computation},
+  volume={21},
+  number={7},
+  pages={3691--3699},
+  year={2025},
+  publisher={ACS Publications}
+}
+```
+
+## License
+
+DeepDriveWE-Academy is released under the
+[MIT License](https://github.com/braceal/deepdrivewe-academy/blob/main/LICENSE).

--- a/docs/tutorials/openmm-ntl9-hk.md
+++ b/docs/tutorials/openmm-ntl9-hk.md
@@ -1,0 +1,346 @@
+# Tutorial: OpenMM NTL9 Folding with Huber-Kim Resampling
+
+This tutorial walks through a production weighted ensemble workflow that
+folds the [NTL9](https://www.rcsb.org/structure/2HBB) protein (39
+residues) using OpenMM molecular dynamics with Huber-Kim resampling.
+Simulations are orchestrated as Academy agents and distributed across
+GPUs via Parsl.
+
+By the end you will understand how to:
+
+- Configure a weighted ensemble experiment via YAML.
+- Subclass `SimulationAgent` and `WestpaAgent` with custom logic.
+- Launch a GPU-distributed workflow with `run_westpa_workflow`.
+- Resume from checkpoints and extend runs.
+
+## Prerequisites
+
+Create a conda environment with OpenMM:
+
+```bash
+conda create -n deepdrivewe python=3.11 -y
+conda activate deepdrivewe
+conda install -c conda-forge openmm=8.1
+pip install -e '.[dev]'
+```
+
+## File Structure
+
+The example lives in `examples/openmm_ntl9_hk/`:
+
+```
+openmm_ntl9_hk/
+├── main.py              # Entry point: parse args, build ensemble, launch agents
+├── workflow.py          # Agent subclasses and Pydantic config models
+├── config.yaml          # Experiment settings (edit this)
+├── common_files/
+│   └── reference.pdb    # Folded reference structure for RMSD calculation
+└── inputs/
+    └── bstates/
+        └── ntl9.pdb     # Starting (unfolded) basis state structure
+```
+
+## Configuration
+
+All experiment parameters live in a single YAML file. Here is the
+default `config.yaml`:
+
+```yaml
+output_dir: results/
+num_iterations: 100
+
+basis_states:
+  basis_state_dir: inputs/
+  basis_state_ext: .pdb
+  initial_ensemble_members: 4
+
+basis_state_initializer:
+  reference_file: common_files/reference.pdb
+  mda_selection: protein and name CA
+
+target_states:
+  - label: folded
+    pcoord: [1.0]
+
+simulation_config:
+  openmm_config:
+    simulation_length_ns: 0.01    # 10 ps per iteration
+    report_interval_ps: 2.0
+    dt_ps: 0.002
+    temperature_kelvin: 300.0
+    solvent_type: implicit
+  reference_file: common_files/reference.pdb
+
+inference_config:
+  sims_per_bin: 4
+
+compute_config:
+  name: workstation
+  available_accelerators: ["0", "1", "2", "3"]
+```
+
+### Key Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `num_iterations` | 100 | Number of WE iterations to run |
+| `simulation_config.openmm_config.simulation_length_ns` | 0.01 | MD segment length per iteration (ns) |
+| `simulation_config.openmm_config.temperature_kelvin` | 300.0 | Simulation temperature (K) |
+| `simulation_config.openmm_config.solvent_type` | implicit | Solvent model |
+| `inference_config.sims_per_bin` | 4 | Target walker count per bin |
+| `target_states[0].pcoord` | [1.0] | RMSD threshold for the folded state (A) |
+| `compute_config.available_accelerators` | ["0","1","2","3"] | GPU device IDs for Parsl workers |
+
+## How the Workflow Works
+
+`run_westpa_workflow` launches two agent types that communicate
+asynchronously:
+
+```mermaid
+graph LR
+    M["main()"] -->|config.yaml| RW["run_westpa_workflow()"]
+    RW -->|launch on GPU| SA["OpenMMSimAgent(s)"]
+    RW -->|launch on CPU| WA[HuberKimWestpaAgent]
+
+    SA -->|SimResult + contact maps| WA
+    WA -->|"SimMetadata (next iter)"| SA
+
+    RW -->|"wait()"| WA
+```
+
+### OpenMMSimAgent
+
+Each `OpenMMSimAgent` receives a `SimMetadata` object, runs an OpenMM
+simulation (implicit solvent, 10 ps), computes RMSD progress coordinates
+and contact maps, and returns a `SimResult`:
+
+```python
+class OpenMMSimAgent(SimulationAgent):
+    def __init__(
+        self,
+        westpa_handle: Handle[WestpaAgent],
+        sim_config: SimulationConfig,
+        output_dir: Path,
+        logfile: Path | None = None,
+    ) -> None:
+        super().__init__(westpa_handle, logfile=logfile)
+        self.sim_config = sim_config
+        self.output_dir = output_dir
+
+    def run_simulation(self, metadata: SimMetadata) -> SimResult:
+        metadata.mark_simulation_start()
+
+        # Set up output directory for this walker
+        sim_output_dir = self.output_dir / metadata.simulation_name
+        sim_output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Create and run the OpenMM simulation
+        simulation = OpenMMSimulation(
+            config=self.sim_config.openmm_config,
+            top_file=self.sim_config.top_file,
+            output_dir=sim_output_dir,
+            checkpoint_file=metadata.parent_restart_file,
+        )
+
+        reporter = ContactMapRMSDReporter(
+            report_interval=self.sim_config.openmm_config.report_steps,
+            reference_file=self.sim_config.reference_file,
+            cutoff_angstrom=self.sim_config.cutoff_angstrom,
+            mda_selection=self.sim_config.mda_selection,
+            openmm_selection=self.sim_config.openmm_selection,
+        )
+
+        simulation.run(reporters=[reporter])
+
+        # Extract results
+        contact_maps = reporter.get_contact_maps()
+        pcoord = reporter.get_rmsds()
+
+        metadata.restart_file = simulation.restart_file
+        metadata.pcoord = pcoord.tolist()
+        metadata.mark_simulation_end()
+
+        return SimResult(
+            data={'contact_maps': contact_maps, 'pcoord': pcoord},
+            metadata=metadata,
+        )
+```
+
+The base `SimulationAgent.simulate` action automatically:
+
+1. Waits for the restart file to be visible (handles NFS caching).
+2. Offloads `run_simulation` to a thread pool.
+3. Sends the result to the WestpaAgent.
+
+### HuberKimWestpaAgent
+
+The `HuberKimWestpaAgent` collects results from all walkers and applies
+a three-stage resampling pipeline:
+
+```python
+class HuberKimWestpaAgent(WestpaAgent):
+    def run_inference(
+        self,
+        sim_results: list[SimResult],
+    ) -> tuple[list[SimMetadata], list[SimMetadata], IterationMetadata]:
+        cur_sims = [r.metadata for r in sim_results]
+
+        # 1. Bin walkers along the RMSD progress coordinate
+        binner = RectilinearBinner(
+            bins=[0.0, 1.00, 1.10, 1.20, ...],
+            bin_target_counts=self.inference_config.sims_per_bin,
+            target_state_inds=0,
+        )
+
+        # 2. Recycle walkers that reach the target (RMSD < 1.0 A)
+        recycler = LowRecycler(
+            basis_states=self.basis_states,
+            target_threshold=self.target_states[0].pcoord[0],
+        )
+
+        # 3. Resample: split under-represented, merge over-represented
+        resampler = HuberKimResampler(
+            sims_per_bin=self.inference_config.sims_per_bin,
+        )
+
+        return resampler.run(cur_sims, binner, recycler)
+```
+
+**Binning** -- Walkers are sorted into rectilinear bins along the RMSD
+progress coordinate. Bins are finer near the target state (0.1 A
+spacing) and coarser far away (0.6 A spacing).
+
+**Recycling** -- Walkers that reach RMSD < 1.0 A are recycled: their
+weight is recorded and they are reset to the unfolded basis state via
+`LowRecycler`.
+
+**Resampling** -- `HuberKimResampler` merges and splits walkers to
+maintain the target count per bin (default: 4) while preserving
+statistical weights.
+
+## Running the Example
+
+From the example directory:
+
+```bash
+cd examples/openmm_ntl9_hk
+python main.py -c config.yaml
+```
+
+Or with the Academy Exchange Cloud (requires
+[Globus](https://www.globus.org/) authentication):
+
+```bash
+python main.py -c config.yaml --exchange globus
+```
+
+!!! note
+    If using the cloud exchange, run the authentication prior to
+    submitting a batch job script. This caches a Globus auth session
+    token on the machine that is reused by subsequent runs.
+
+## What Happens at Startup
+
+1. `ExperimentSettings.from_yaml` parses and validates `config.yaml`.
+2. `EnsembleCheckpointer` checks for existing checkpoints.
+   - If none exist, `WeightedEnsemble` is initialized from basis states
+     with RMSD-based progress coordinates.
+   - If a checkpoint exists, the ensemble is loaded and the workflow
+     resumes from the last completed iteration.
+3. A `ParslPoolExecutor` is created from the compute config to manage
+   GPU workers.
+4. `run_westpa_workflow` registers both agent types, launches them on
+   the appropriate executors, dispatches the first iteration, and waits
+   for completion.
+
+## Output Structure
+
+After running, the `results/` directory contains:
+
+```
+results/
+├── params.yaml              # Copy of the experiment config
+├── runtime.log              # Full runtime log
+├── west.h5                  # WESTPA-compatible HDF5 file
+├── checkpoints/
+│   ├── checkpoint-000001.json
+│   ├── checkpoint-000002.json
+│   └── ...
+├── simulation/
+│   ├── 000001/              # Iteration 1
+│   │   ├── 000000/          # Walker 0
+│   │   ├── 000001/          # Walker 1
+│   │   └── ...
+│   └── ...
+└── run-info/                # Parsl run metadata
+```
+
+## Resuming a Run
+
+Simply re-run the same command. The checkpointer automatically detects
+the latest checkpoint and resumes from that iteration:
+
+```bash
+python main.py -c config.yaml
+```
+
+To extend a completed run, increase `num_iterations` in `config.yaml`
+and re-run.
+
+## Stopping a Running Workflow
+
+If running in the foreground, ++ctrl+c++ stops the workflow. If running
+in the background:
+
+```bash
+kill <pid>
+```
+
+## Customization
+
+### Custom Progress Coordinate
+
+Subclass `SimulationAgent`, override `run_simulation`, and return
+different values in `metadata.pcoord`. Replace the
+`ContactMapRMSDReporter` with your own reporter.
+
+### Different Resampling Strategy
+
+Subclass `WestpaAgent`, override `run_inference`, and use a different
+binner/recycler/resampler combination. Available options:
+
+| Component | Options |
+|-----------|---------|
+| Binners | [`RectilinearBinner`][deepdrivewe.binners.rectilinear.RectilinearBinner], [`MultiRectilinearBinner`][deepdrivewe.binners.multirectilinear.MultiRectilinearBinner] |
+| Recyclers | [`LowRecycler`][deepdrivewe.recyclers.low.LowRecycler], [`HighRecycler`][deepdrivewe.recyclers.high.HighRecycler] |
+| Resamplers | [`HuberKimResampler`][deepdrivewe.resamplers.huber_kim.HuberKimResampler], [`SplitLowResampler`][deepdrivewe.resamplers.low.SplitLowResampler], [`SplitHighResampler`][deepdrivewe.resamplers.high.SplitHighResampler], [`LOFLowResampler`][deepdrivewe.resamplers.lof.LOFLowResampler] |
+
+### HPC Clusters
+
+Change the `compute_config` section in `config.yaml` to target your HPC
+scheduler. See `deepdrivewe.parsl` for supported backends:
+
+=== "Workstation (multi-GPU)"
+
+    ```yaml
+    compute_config:
+      name: workstation
+      available_accelerators: ["0", "1", "2", "3"]
+    ```
+
+=== "Slurm"
+
+    ```yaml
+    compute_config:
+      name: vista
+      available_accelerators: ["0", "1", "2"]
+      # Additional Slurm-specific fields...
+    ```
+
+=== "Local (single CPU)"
+
+    ```yaml
+    compute_config:
+      name: local
+      max_workers_per_node: 1
+    ```

--- a/examples/openmm_ntl9_hk/config.yaml
+++ b/examples/openmm_ntl9_hk/config.yaml
@@ -55,5 +55,5 @@ inference_config:
 compute_config:
   name: workstation
   # Number of GPUs available
-  # The numbers below are analogous to setting CUDA_VISIBLE_DEVICES=1,2,3
-  available_accelerators: ["1", "2", "3"]
+  # The numbers below are analogous to setting CUDA_VISIBLE_DEVICES=0,1,2,3
+  available_accelerators: ["0", "1", "2", "3"]

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -1,0 +1,85 @@
+site_name: DeepDriveWE-Academy
+site_description: >-
+  Weighted ensemble molecular dynamics using the Academy
+  multi-agent framework.
+site_url: https://braceal.github.io/deepdrivewe-academy
+repo_url: https://github.com/braceal/deepdrivewe-academy
+repo_name: braceal/deepdrivewe-academy
+
+theme:
+  name: material
+  palette:
+    - media: '(prefers-color-scheme: light)'
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: '(prefers-color-scheme: dark)'
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - content.code.copy
+    - content.code.annotate
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.highlight
+    - toc.follow
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.tabbed:
+      alternate_style: true
+  - toc:
+      permalink: true
+  - attr_list
+  - md_in_html
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: numpy
+            show_root_heading: true
+            show_source: true
+            members_order: source
+            show_signature_annotations: true
+            separate_signature: true
+  - gen-files:
+      scripts:
+        - docs/gen_ref_pages.py
+  - literate-nav:
+      nav_file: SUMMARY.md
+  - section-index
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Installation: getting-started/installation.md
+      - Quickstart: getting-started/quickstart.md
+      - Claude Skill: getting-started/claude-skill.md
+  - Concepts:
+      - Weighted Ensemble: concepts/weighted-ensemble.md
+      - Architecture: concepts/architecture.md
+  - Tutorials:
+      - OpenMM NTL9 Folding: tutorials/openmm-ntl9-hk.md
+  - API Reference: reference/
+  - Contributing: contributing.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,12 +55,13 @@ dev = [
 ]
 docs = [
     "black",
+    "properdocs",
     "mkdocs-gen-files",
     "mkdocs-literate-nav",
-    "mkdocs-material==9.4.7",
+    "mkdocs-material>=9.5",
     "mkdocs-section-index",
-    "mkdocstrings==0.23.0",
-    "mkdocstrings-python==1.8.0",
+    "mkdocstrings>=0.26",
+    "mkdocstrings-python>=1.12",
     "mike",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,4 +15,4 @@ commands = pre-commit run --all-files --show-diff-on-failure
 
 [testenv:docs]
 extras = docs
-commands = mkdocs build --strict
+commands = properdocs build --strict


### PR DESCRIPTION
## Summary

- Adds a full documentation site built with [ProperDocs](https://properdocs.org/) (an MkDocs 1.x continuation) and the Material theme, with an auto-generated API reference via mkdocstrings.
- Adds a Claude Code skill ([`deepdrivewe-example`](/.claude/skills/deepdrivewe-example/SKILL.md)) that guides Claude through creating a new DeepDriveWE example end-to-end. The skill is auto-discovered when the repo is open in Claude Code.
- Updates the README with the Leung et al. 2025 citation (+ BibTeX), adds a Citation section to the docs home page, and includes the WESTPA (Zwier 2015) and Zuckerman & Chong 2017 review in Further Reading.

### Docs pages
- Home (index.md) with features, quick example, citation, Claude skill callout
- Getting Started: Installation, Quickstart, Claude Skill
- Concepts: Weighted Ensemble, Architecture
- Tutorials: OpenMM NTL9 Folding walkthrough
- API Reference: auto-generated from docstrings for every module in ``deepdrivewe/``
- Contributing: dev setup, tests, linting, docs build, PR workflow

### Build / tooling
- ``pyproject.toml`` docs extras updated: ``properdocs``, ``mkdocs-material>=9.5``, ``mkdocstrings>=0.26``, ``mkdocstrings-python>=1.12``.
- ``tox.ini`` docs env and ``.claude/CLAUDE.md`` reference ``properdocs build --strict``.
- Fixed docstring parameter mismatches in ``deepdrivewe/ai/utils.py`` (``pcords`` -> ``pcoords``; removed bogus ``x``/``y``/``xlabel``/``ylabel`` params on ``plot``) so strict-mode build passes.
- Excluded ``properdocs.yml`` from the ``check-yaml`` pre-commit hook (it uses pymdownx's ``!!python/name:`` tag which is valid for MkDocs/ProperDocs but not safe-loadable).
- Added ``site/`` to ``.gitignore``.

## Test plan

- [x] ``pip install -e '.[dev,docs]'``
- [x] ``properdocs build --strict`` passes locally
- [x] ``properdocs serve`` renders all nav pages correctly (Home, Installation, Quickstart, Claude Skill, Weighted Ensemble, Architecture, OpenMM NTL9, API Reference, Contributing)
- [x] API reference pages resolve for every module in ``deepdrivewe/``
- [x] Auto-ref cross-links in concept/tutorial tables (e.g. ``RectilinearBinner``, ``HuberKimResampler``) navigate to the correct reference pages
- [x] ``tox -e docs`` passes
- [x] ``pre-commit run --all-files`` passes
- [x] Claude Code picks up the ``deepdrivewe-example`` skill when the repo is open