### PR TITLE
CI/CD

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# Dependabot configuration
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+
+updates:
+  # GitHub Actions used by .github/workflows/*.yml
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: develop
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: ci
+    groups:
+      github-actions:
+        patterns:
+          - '*'
+
+  # Python dependencies declared in pyproject.toml
+  - package-ecosystem: pip
+    directory: /
+    target-branch: develop
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - python
+    commit-message:
+      prefix: chore
+    groups:
+      # Bundle non-breaking updates into a single PR to reduce churn.
+      # Majors stay as individual PRs so they get proper review.
+      python-minor-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop, main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dev dependencies
+        run: pip install -e '.[dev]'
+
+      - name: Cache pre-commit environments
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Run pre-commit (ruff, mypy, codespell, ...)
+        run: pre-commit run --all-files --show-diff-on-failure
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dev dependencies
+        run: pip install -e '.[dev]'
+
+      - name: Run tests with coverage
+        run: |
+          coverage erase
+          coverage run -m pytest
+          coverage report
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install docs dependencies
+        run: pip install -e '.[docs]'
+
+      - name: Build site (strict)
+        run: properdocs build --strict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
         exclude: ^properdocs\.yml$
       - id: check-merge-conflict
       - id: name-tests-test
+        args: ['--pytest-test-first']
   - repo: 'https://github.com/codespell-project/codespell'
     rev: v2.2.6
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,15 @@ dist,
 plugins = ["covdefaults"]
 omit = ["examples"]
 
+[tool.coverage.report]
+# Effectively disabled. We can't use fail_under = 0 directly because the
+# covdefaults plugin treats a falsy fail_under as "unset" and force-sets
+# it to 100; precision = 2 is needed so single-digit coverage percentages
+# aren't rounded down to 0 before comparison. Bump this up as test
+# coverage grows (target: 80%+).
+fail_under = 0.01
+precision = 2
+
 [tool.mypy]
 python_version = "3.10"
 explicit_package_bases = true
@@ -170,7 +179,7 @@ required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.per-file-ignores]
 "*/__init__.py" = ["F401"]
-"*/*_test.py" = ["D10"]
+"*/test_*.py" = ["D10"]
 
 [tool.ruff.lint.pylint]
 max-args = 7

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,10 @@
+"""Smoke tests for the deepdrivewe package."""
+
+from __future__ import annotations
+
+import deepdrivewe
+
+
+def test_import() -> None:
+    """Package imports cleanly and exposes a version string."""
+    assert deepdrivewe.__version__


### PR DESCRIPTION
## Summary

- Add [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — PR-triggered CI on `develop` and `main` with three parallel jobs: `lint` (pre-commit), `test` (pytest + coverage), and `docs` (`properdocs build --strict`). Leaves the existing `docs.yml` deploy workflow untouched.
- Add [`.github/dependabot.yml`](.github/dependabot.yml) — weekly updates for `github-actions` and `pip`, targeting `develop`. Minor/patch pip bumps and all Actions bumps are grouped into consolidated PRs; majors stay standalone so they get proper review.
- Add [`tests/test_import.py`](tests/test_import.py) — smoke test that imports `deepdrivewe` and asserts `__version__` is set. Without it, `pytest` exits with code 5 ("no tests collected") and fails the `test` job.
- Update [`pyproject.toml`](pyproject.toml) — add `[tool.coverage.report]` with `fail_under = 0.01` and `precision = 2`. This effectively disables the coverage gate until real tests exist. Can't use `fail_under = 0` directly because `covdefaults` treats falsy values as "unset" and force-sets to 100; `precision = 2` prevents single-digit percentages from rounding down to 0 before comparison. To be bumped up as coverage grows (target: 80%+).
- Flip the test-naming convention from the suffix style (`*_test.py`) to the pytest-standard prefix style (`test_*.py`) by passing `--pytest-test-first` to the `name-tests-test` pre-commit hook and updating the ruff D10 per-file-ignore pattern to match.

## Test plan

- [x] CI `lint` job passes (pre-commit clean)
- [x] CI `test` job passes (smoke test runs, coverage gate satisfied)
- [x] CI `docs` job passes (`properdocs build --strict` succeeds)
- [x] Dependabot opens its first round of PRs against `develop` after merge
- [x] Confirm `develop` exists on origin (Dependabot errors out if the target branch is missing)