### PR TITLE
chore: drop unused setuptools_scm from build requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64.0", "setuptools_scm"]
+requires = ["setuptools>=64.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
setuptools_scm was declared as a build dependency but never activated ([project].version is hardcoded, there is no dynamic = ["version"] and no [tool.setuptools_scm] section), so it was installed in every build environment and did nothing. Removing it is a no-op for produced artifacts and keeps the hardcoded 0.1.0 as the single source of truth until the release flow is revisited.