### PR TITLE
docs: document conventional-commit bump rules for auto-releases

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -82,3 +82,21 @@ Key domain dependencies: `mdtraj`, `MDAnalysis` (trajectory analysis), `parsl` (
 - **PRs target**: `develop`; release PRs go `develop` → `main`
 - **Branch naming**: `feature/<issue>-<slug>`, `bugfix/<issue>-<slug>`, `chore/<issue>-<slug>`
 - A PreToolUse hook redirects `git checkout main` to `develop`
+
+## Releases
+
+Releases are automated by `release-please` via the [Release workflow](../.github/workflows/release.yml). Every merge to `main` either opens or updates a "release PR". Merging that release PR creates the `vX.Y.Z` tag, a GitHub Release, a `CHANGELOG.md` entry, and bumps the version in `pyproject.toml`.
+
+**Commit messages drive the bump** — use [Conventional Commits](https://www.conventionalcommits.org/). While the version is `< 1.0.0` (config uses `bump-minor-pre-major: true`):
+
+| Commit type                                              | Bump                  |
+|----------------------------------------------------------|-----------------------|
+| `feat!:` or `BREAKING CHANGE:` in body                   | minor (capped pre-1.0) |
+| `feat:`                                                  | minor                 |
+| `fix:`                                                   | patch                 |
+| `perf:`                                                  | patch                 |
+| `chore:`, `ci:`, `docs:`, `test:`, `refactor:`, `style:` | no release            |
+
+After `1.0.0`, standard SemVer applies and `feat!:` bumps the major. The highest-severity commit in the batch wins. To force a specific version, add `Release-As: X.Y.Z` to a commit body on `main`.
+
+Version source of truth is `pyproject.toml`; `deepdrivewe/__init__.py` reads it via `importlib.metadata.version()`, so no other version string needs updating when cutting a release.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -84,3 +84,48 @@ Then open <http://localhost:8000> in your browser to preview.
 3. Write tests for new functionality.
 4. Make sure `pre-commit run --all-files` and `pytest` pass.
 5. Open a PR targeting `develop`.
+
+## Commit Messages & Releases
+
+This project uses
+[Conventional Commits](https://www.conventionalcommits.org/). Commit
+types are not decorative — they drive automated releases. Every merge
+to `main` runs
+[release-please](https://github.com/googleapis/release-please), which
+reads the commits since the last tag and either opens or updates a
+"release PR". Merging that release PR creates the git tag (`vX.Y.Z`),
+the GitHub Release, a `CHANGELOG.md` entry, and the bumped version
+in `pyproject.toml`.
+
+### Version bump rules
+
+While the version is `< 1.0.0`, release-please runs with
+`bump-minor-pre-major: true`, so breaking changes stay capped at a
+minor bump:
+
+| Commit type                              | Bump       | Example           |
+|------------------------------------------|------------|-------------------|
+| `feat!:` or `BREAKING CHANGE:` in body   | minor      | `0.1.0` → `0.2.0` |
+| `feat:`                                  | minor      | `0.1.0` → `0.2.0` |
+| `fix:`                                   | patch      | `0.1.0` → `0.1.1` |
+| `perf:`                                  | patch      | `0.1.0` → `0.1.1` |
+| `chore:`, `ci:`, `docs:`, `test:`, `refactor:`, `style:` | no release | —     |
+
+Once the project cuts `1.0.0`, standard [Semantic Versioning](https://semver.org/)
+rules apply and `feat!:` bumps the major (`1.2.3` → `2.0.0`).
+
+The highest-severity commit in the batch wins — one `feat:` among
+several `fix:` commits yields a minor bump, not a patch. A batch of
+only `chore:` / `ci:` / `docs:` commits produces no release PR at all.
+
+### Forcing a specific version
+
+To override the automatic bump (for example, to graduate out of `0.x`),
+include a `Release-As:` trailer in any commit body on `main`:
+
+```
+Release-As: 1.0.0
+```
+
+The next release PR will use that version instead of the one inferred
+from commit types.


### PR DESCRIPTION
## Summary
- Adds a **Commit Messages & Releases** section to `docs/contributing.md` explaining how `release-please` maps Conventional Commit types to version bumps, plus the `Release-As:` override for forcing a specific version.
- Adds a matching **Releases** section to `.claude/CLAUDE.md` so Claude sessions pick the right commit types when authoring commits in this repo.
- No code or workflow changes — this purely formalizes the commit discipline the release workflow added in #24 relies on.

## Why
After wiring up `release-please` in #24, the version-bump behavior (particularly the `bump-minor-pre-major: true` pre-1.0 cap and the fact that `chore:`/`ci:`/`docs:` commits do not trigger releases) was only documented in PR comments. Capturing it in the contributing guide + `CLAUDE.md` makes it discoverable for both human contributors and assisted sessions.

## Test plan
- [x] `properdocs build --strict` passes locally (only pre-existing INFO about `../reference/` in `quickstart.md`, unrelated).
- [x] Pre-commit hooks pass (codespell, trailing whitespace, etc.).
- [ ] On merge, confirm the rendered "Commit Messages & Releases" section appears on the published docs site.
- [ ] This PR is itself a `docs:` commit and should **not** trigger a version bump — verify the next `release-please` PR on `main` is unchanged.