### PR TITLE
docs: add status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # deepdrivewe-academy
-Academy implementation of DeepDriveWE.
+
+[![CI](https://github.com/ramanathanlab/deepdrivewe-academy/actions/workflows/ci.yml/badge.svg)](https://github.com/ramanathanlab/deepdrivewe-academy/actions/workflows/ci.yml)
+[![Docs](https://github.com/ramanathanlab/deepdrivewe-academy/actions/workflows/docs.yml/badge.svg?branch=main)](https://ramanathanlab.github.io/deepdrivewe-academy)
+[![Release](https://img.shields.io/github/v/release/ramanathanlab/deepdrivewe-academy?include_prereleases&sort=semver)](https://github.com/ramanathanlab/deepdrivewe-academy/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 Implementation of [DeepDriveWE](https://pubs.acs.org/doi/full/10.1021/acs.jctc.4c01136) using [Academy](https://docs.academy-agents.org/stable/).
 


### PR DESCRIPTION
## Summary
Adds seven status badges to the top of the README:

- **CI** — status of the lint / test / docs-build workflow
- **Docs** — status of the Deploy Docs workflow; the badge itself links to the published site at https://ramanathanlab.github.io/deepdrivewe-academy
- **Release** — latest GitHub Release tag (auto-populates once `release-please` cuts the first tag)
- **License: MIT** — matches `pyproject.toml`
- **Python 3.10+** — matches what CI actually tests
- **pre-commit** — signals that `pre-commit install` is part of setup
- **Ruff** — the official astral-sh endpoint badge

No code changes.

## Test plan
- [x] After merge, verify badges render on the repo's README on GitHub.
- [x] Confirm the Docs badge click-through lands on the live documentation site.
- [x] Confirm the Release badge populates `v0.2.0` (or current latest) once PR #26 — the open `release-please` PR — is merged.