### PR TITLE
docs: Add status badges to README for CI and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # deepdrivewe-academy
-Academy implementation of DeepDriveWE.
+
+[![CI](https://github.com/ramanathanlab/deepdrivewe-academy/actions/workflows/ci.yml/badge.svg)](https://github.com/ramanathanlab/deepdrivewe-academy/actions/workflows/ci.yml)
+[![Docs](https://github.com/ramanathanlab/deepdrivewe-academy/actions/workflows/docs.yml/badge.svg?branch=main)](https://ramanathanlab.github.io/deepdrivewe-academy)
+[![Release](https://img.shields.io/github/v/release/ramanathanlab/deepdrivewe-academy?include_prereleases&sort=semver)](https://github.com/ramanathanlab/deepdrivewe-academy/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 Implementation of [DeepDriveWE](https://pubs.acs.org/doi/full/10.1021/acs.jctc.4c01136) using [Academy](https://docs.academy-agents.org/stable/).
 


### PR DESCRIPTION
This pull request updates the `README.md` to improve project visibility and documentation. The most important change is the addition of several status and informational badges to the top of the file.

Enhancements to project documentation and visibility:

* Added badges for CI status, documentation, release version, license, Python version, pre-commit, and Ruff linter to the top of the `README.md` to provide quick project status and metadata.