### PR TITLE
fix: reset resampler index counter after _get_next_sims

### DIFF
--- a/deepdrivewe/resamplers/base.py
+++ b/deepdrivewe/resamplers/base.py
@@ -47,6 +47,12 @@ class Resampler(ABC):
         # Get the next iteration of simulation metadata
         next_sims = self._get_next_sims(cur_sims)
 
+        # _get_next_sims assigns simulation_id = 0..N-1 via enumerate.
+        # Reset the counter so _add_new_simulation (used by split/merge)
+        # starts at N, preventing ID collisions between continuation
+        # walkers and any new walkers created by resampling.
+        self._index_counter = itertools.count(len(next_sims))
+
         # Recycle the current iteration
         cur_sims, next_sims = recycler.recycle_simulations(cur_sims, next_sims)
 


### PR DESCRIPTION
Fixes #33

## Summary

- `_get_next_sims` assigns `simulation_id = 0..N-1` via `enumerate`, leaving `_index_counter` at 0
- Any split/merge walkers created in the same `run()` call then received duplicate IDs starting from 0, colliding with continuation walkers
- This caused `FileNotFoundError` for trajectory files when the duplicate ID resolved to the wrong iteration directory

## Change

Reset `_index_counter` to `itertools.count(len(next_sims))` immediately after `_get_next_sims` in `Resampler.run()`, so split/merge walkers always receive IDs ≥ N.

Files changed: `deepdrivewe/resamplers/base.py` (+6 lines)

## Test plan

- [ ] Run the `openmm_ntl9_hk` example with a resampler that triggers split/merge (walker count > target) and confirm no `FileNotFoundError` for trajectory files after resampling
- [ ] Verify split/merge walkers in the same iteration receive IDs ≥ N (no overlap with continuation walker IDs 0..N-1)