### PR TITLE
fix: patch aiohttp DEFAULT_TIMEOUT to prevent SSE listener timeout after 300 s

### DIFF
--- a/deepdrivewe/workflows/westpa.py
+++ b/deepdrivewe/workflows/westpa.py
@@ -48,7 +48,6 @@ from typing import Any
 
 import aiohttp
 import aiohttp.client
-
 from academy.agent import action
 from academy.agent import Agent
 from academy.agent import loop

--- a/deepdrivewe/workflows/westpa.py
+++ b/deepdrivewe/workflows/westpa.py
@@ -46,6 +46,9 @@ from abc import abstractmethod
 from pathlib import Path
 from typing import Any
 
+import aiohttp
+import aiohttp.client
+
 from academy.agent import action
 from academy.agent import Agent
 from academy.agent import loop
@@ -102,6 +105,20 @@ class SimulationAgent(Agent, ABC):
         logfile: Path | None = None,
     ) -> None:
         super().__init__()
+        # Patch the aiohttp default session timeout so the SSE listener
+        # survives long-running iterations.  Academy creates the exchange
+        # ClientSession (step 1 of run_until_complete) AFTER __init__, so
+        # setting DEFAULT_TIMEOUT here is the earliest reliable hook.
+        # This is especially important for sim agents running inside Parsl
+        # worker subprocesses: those processes never execute main.py, so
+        # without this patch they inherit aiohttp's default total=300 s and
+        # the SSE listener times out after 5 minutes, causing agents to stop
+        # receiving new simulation tasks.
+        aiohttp.client.DEFAULT_TIMEOUT = aiohttp.ClientTimeout(
+            total=None,
+            sock_connect=30,
+            sock_read=None,
+        )
         self.westpa_handle = westpa_handle
         self.logfile = logfile
 

--- a/examples/openmm_ntl9_hk/main.py
+++ b/examples/openmm_ntl9_hk/main.py
@@ -26,6 +26,8 @@ from argparse import ArgumentParser
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+import aiohttp
+import aiohttp.client
 from academy.exchange.cloud.client import HttpExchangeFactory
 from academy.exchange.local import LocalExchangeFactory
 from academy.logging import init_logging
@@ -38,6 +40,26 @@ from workflow import OpenMMSimAgent
 from deepdrivewe.api import WeightedEnsemble
 from deepdrivewe.checkpoint import EnsembleCheckpointer
 from deepdrivewe.workflows.westpa import run_westpa_workflow
+
+# Override aiohttp's default timeout for the orchestrator's exchange session:
+#   total=None      — no per-request wall-clock limit; long iterations with
+#                     many walkers would otherwise hit the default total=300s
+#                     and drop the SSE connection mid-run.
+#   sock_read=None  — no idle-read timeout on the socket. The SSE server is
+#                     supposed to flush within request_timeout_s=60 s, but
+#                     under load (e.g. 200+ sims dispatched at once) it can
+#                     miss that window. A finite sock_read kills the agents'
+#                     SSE listener, making them deaf to future tasks.
+#                     Hung PUT requests are guarded instead by the semaphore
+#                     and per-attempt retries in dispatch_round_robin.
+#   sock_connect=30 — keep a reasonable TCP-handshake limit.
+# Note: Parsl worker processes never execute this module, so they are covered
+# by the matching patch in SimulationAgent.__init__ instead.
+aiohttp.client.DEFAULT_TIMEOUT = aiohttp.ClientTimeout(
+    total=None,
+    sock_connect=30,
+    sock_read=None,
+)
 
 EXCHANGE_ADDRESS = 'https://exchange.academy-agents.org'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "natsort>=8.4.0",
     "matplotlib>=3.9.2",
     "academy-py>=0.1.0",
+    "aiohttp>=3.9.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

Fixes #37.

aiohttp's default `ClientTimeout(total=300)` causes the Academy SSE listener to raise `TimeoutError` after exactly 5 minutes, making agents permanently deaf to further simulation tasks. Two process types are affected and require separate patches:

- **Parsl worker processes** (`SimulationAgent.__init__`) — workers run as fresh `process_worker_pool.py` subprocesses that never execute `main.py`, so the patch must be applied inside `__init__`, which runs on the worker before Academy's `run_until_complete()` creates the `ClientSession`.
- **Orchestrator process** (`main.py`) — the orchestrator's own Academy exchange session is also subject to the default; patched at module level before any session is created.

Both patches set `total=None, sock_read=None, sock_connect=30`.

> **Note:** This is a workaround. The proper fix is for Academy to expose a configurable timeout on its exchange client. This should be raised as a feature request upstream in `academy-py`.

## Changes

- `deepdrivewe/workflows/westpa.py` — `SimulationAgent.__init__` sets `aiohttp.client.DEFAULT_TIMEOUT` before Academy startup (cherry-pick of `b37bef6` from `example-deadlocks`)
- `examples/openmm_ntl9_hk/main.py` — module-level `aiohttp.client.DEFAULT_TIMEOUT` override for the orchestrator process
- `pyproject.toml` — declares `aiohttp>=3.9.0` as a direct dependency since `westpa.py` now imports it explicitly

## Observed errors

```
TimeoutError
  File ".../aiohttp/helpers.py", line 713, in __exit__
    raise asyncio.TimeoutError from exc_val
```

Fired exactly ~300 s after Parsl worker sim agents established their SSE connections in `slurm-5528681` (iter 11, 72 walkers) and `slurm-5540646` (iter 17, 88 walkers).

## Test plan

- [ ] Run `openmm_ntl9_hk` example with enough walkers that iterations take >5 minutes
- [ ] Confirm sim agents remain responsive past the 5-minute mark (no `TimeoutError` in logs)
- [ ] Confirm workflow runs to completion rather than hanging at wall time