### PR TITLE
chore: enable pre-commit.ci weekly autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,11 @@
 ci:
   autofix_prs: false
+  # pre-commit.ci opens a weekly PR that runs `pre-commit autoupdate`,
+  # bumping hook revisions in this file. PRs target `develop` to match
+  # the project's integration branch (see CLAUDE.md).
+  autoupdate_branch: develop
+  autoupdate_schedule: weekly
+  autoupdate_commit_msg: 'chore: pre-commit autoupdate'
 repos:
   - repo: 'https://github.com/pre-commit/pre-commit-hooks'
     rev: v4.5.0


### PR DESCRIPTION
## Summary

- Adds `autoupdate_branch`, `autoupdate_schedule`, and `autoupdate_commit_msg` to the existing `ci:` block in `.pre-commit-config.yaml`.
- pre-commit.ci will now open a weekly PR against `develop` that runs `pre-commit autoupdate`, keeping hook revisions current without manual `pre-commit autoupdate` runs.
- Existing `autofix_prs: false` is preserved — pre-commit.ci will not push fixup commits onto contributor PRs.

## Notes

- The pre-commit.ci GitHub App is already installed on this repo (verified by the user), so the config takes effect on the next scheduled tick.
- This is independent of the test-suite work in `feature/41-test-suite` — it can land in any order.

## Test plan

- [ ] Merge to `develop`.
- [ ] Within ~7 days, confirm pre-commit.ci opens an autoupdate PR titled `chore: pre-commit autoupdate` targeting `develop`.